### PR TITLE
Add ability to extend/override core.SQLALCHEMY_ENGINES

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ M2M sample::
 
     User.sa.query().join(User.sa.groups).filter(Group.sa.name=="GROUP_NAME")
 
-Explicit joins is part of SQLAlchemy philosophy, so aldjemy can't get you exactly 
+Explicit joins is part of SQLAlchemy philosophy, so aldjemy can't get you exactly
 the same experience as Django.
 But aldjemy is not positioned as Django ORM drop-in replacement. It's a helper for special situations.
 
@@ -56,11 +56,17 @@ You can use this stuff if you need - maybe you want to build queries with tables
 Settings
 --------
 
-You can add your own field types to map django types to sqlalchemy ones with 
-``ALDJEMY_DATA_TYPES`` settings parameter.
-
-Parameter must be a ``dict``, keys is result of ``field.get_internal_type()``,
+You can add your own field types to map django types to sqlalchemy ones with
+``ALDJEMY_DATA_TYPES`` settings parameter.  
+Parameter must be a ``dict``, key is result of ``field.get_internal_type()``,
 value must be a one arg function. You can get idea from ``aldjemy.types``.
+  
+Also it is possible to extend/override list of supported SQLALCHEMY engines
+using ``ALDJEMY_ENGINES`` settings parameter.  
+Parameter should be a ``dict``, key is substring after last dot from 
+Django database engine setting (e.g. ``sqlite3`` from ``django.db.backends.sqlite3``),
+value is SQLAlchemy driver which will be used for connection (e.g. ``sqlite``, ``sqlite+pysqlite``).
+It could be helpful if you want to use ``django-postgrespool``.
 
 
 Mixins

--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -1,4 +1,5 @@
 from django.db import connection
+from django.conf import settings
 from sqlalchemy import MetaData, create_engine
 from sqlalchemy.pool import NullPool
 from sqlalchemy.pool import _ConnectionRecord as _ConnectionRecordBase
@@ -23,6 +24,7 @@ SQLALCHEMY_ENGINES = {
     'postgresql_psycopg2': 'postgresql+psycopg2',
     'oracle': 'oracle',
 }
+SQLALCHEMY_ENGINES.update(getattr(settings, 'ALDJEMY_ENGINES', {}))
 
 
 def get_engine_string():

--- a/test_project/sample/tests.py
+++ b/test_project/sample/tests.py
@@ -18,3 +18,7 @@ class SimpleTest(TestCase):
         self.assertTrue(StaffAuthor.sa)
         self.assertTrue(Review.sa)
         self.assertTrue(BookProxy.sa)
+
+    def test_engine_override_test(self):
+        from aldjemy import core
+        self.assertEquals(core.get_connection_string(), 'sqlite+pysqlite://')

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -20,6 +20,10 @@ DATABASES = {
     }
 }
 
+ALDJEMY_ENGINES = {
+    'sqlite3': 'sqlite+pysqlite'
+}
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.


### PR DESCRIPTION
Add ability to extend/override core.SQLALCHEMY_ENGINES with settings.ALDJEMY_ENGINES. It is necessary for using custom SQLAlchemy drivers and custom Django backends (e.g. https://github.com/kennethreitz/django-postgrespool)
