### PR TITLE
Fix HSTORE support and save some keystrokes.

### DIFF
--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -97,7 +97,7 @@ class _ConnectionRecord(_ConnectionRecordBase):
 
         self.alias = alias
         self.wrap = False
-        #pool.dispatch.first_connect.exec_once(self.connection, self)
+        pool.dispatch.first_connect.exec_once(self.connection, self)
         pool.dispatch.connect(self.connection, self)
         self.wrap = True
 

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -97,6 +97,8 @@ def prepare_models():
             name = model._meta.db_table
             orm.mapper(sa_models[name], table, attrs)
         model.sa = sa_models[name]
+        model.t = tables[name]
+        model.c = model.t.c
 
     Cache.models = sa_models
 
@@ -108,3 +110,9 @@ class BaseSQLAModel(object):
         if a or kw:
             return get_session(alias).query(*a, **kw)
         return get_session(alias).query(cls)
+
+    @classmethod
+    def bind(cls, sel):
+        alias = getattr(cls, 'alias', 'default')
+        sel.bind = get_engine(alias)
+        return sel


### PR DESCRIPTION
Since building complex queries using sqlalchemy's expression api involves lots of tokens like `Model.sa.table` and `Model.sa.table.fieldname`, so i'd like to shorten them to `Model.t` and `Model.c.fieldname`.
Also i add a `bind` method to execute an arbitrary `selectable` object.
