### PR TITLE
Expand support matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,19 +7,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
-        django-version: ["1.7", "1.8", "1.9", "1.10", "1.11", "2.0", "2.1"]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        django-version: ["1.7", "1.8", "1.9", "1.10", "1.11", "2.0", "2.1", "2.2", "3.0"]
         exclude:
           - python-version: 2.7
             django-version: "2.0"
           - python-version: 2.7
             django-version: "2.1"
+          - python-version: 2.7
+            django-version: "2.2"
+          - python-version: 2.7
+            django-version: "3.0"
           - python-version: 3.5
             django-version: "1.7"
+          - python-version: 3.5
+            django-version: "3.0"
           - python-version: 3.6
             django-version: "1.7"
           - python-version: 3.7
             django-version: "1.7"
+          - python-version: 3.8
+            django-version: "1.7"
+          - python-version: 3.8
+            django-version: "1.8"
+          - python-version: 3.8
+            django-version: "1.9"
+          - python-version: 3.8
+            django-version: "1.10"
+          - python-version: 3.8
+            django-version: "1.11"
+          - python-version: 3.8
+            django-version: "2.0"
+          - python-version: 3.8
+            django-version: "2.1"
 
     steps:
       - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ve/
 .tox
 .idea*
 .venv*
+/.vscode/

--- a/test_project/sample/routers.py
+++ b/test_project/sample/routers.py
@@ -26,6 +26,8 @@ class LogsRouter(object):
     else:
 
         def allow_migrate(self, db, app_label, model_name=None, **hints):
+            if app_label in ("sites", "contenttypes", "auth"):
+                return True
             model = hints.get("model", None)
             if model is None:
                 return None

--- a/test_project/sample/tests.py
+++ b/test_project/sample/tests.py
@@ -52,7 +52,8 @@ class SimpleTest(TestCase):
 
 
 class AliasesTest(TestCase):
-    multi_db = True
+    multi_db = True  # Django<2.2
+    databases = "__all__"
 
     def test_engines_cache(self):
         from aldjemy.core import Cache, get_engine
@@ -85,7 +86,8 @@ class AliasesTest(TestCase):
 
 
 class AldjemyMetaTests(TestCase):
-    multi_db = True
+    multi_db = True  # Django<2.2
+    databases = "__all__"
 
     def test_meta(self):
         from sample.models import Log

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,25 @@
 [tox]
 envlist =
-    {py27,py35,py36}-django{18,19,110,111}
-    {py35,py36,py37}-django{20,21}
     py27-django17
+    {py27,py35,py36}-django{18,19,110,111}
+    {py35,py36,py37}-django{20,21,22}
+    py38-django{22,30}
 
 [testenv]
 commands = ./test.sh {posargs}
 deps =
-     django-extensions==1.6.1
-     django17: django==1.7.11
-     django18: django==1.8.18
-     django19: django==1.9.13
-     django110: django==1.10.7
-     django111: django==1.11.2
-     django20: django==2.0.9
-     django21: django==2.1.3
-     six==1.10.0
-     sqlalchemy==1.0.12
+    django17: django~=1.7.0
+    django18: django~=1.8.0
+    django19: django~=1.9.0
+    django110: django~=1.10.0
+    django111: django~=1.11.0
+    django20: django~=2.0.0
+    django21: django~=2.1.0
+    django22: django~=2.2.0
+    django30: django~=3.0.0
+    six
+    sqlalchemy
+    django-extensions
 setenv =
     PY27_DJANGO17 = 0
 


### PR DESCRIPTION
Include Django 2.2 and 3.0, and matching Python versions. No deprecation of supporting versions is included, as that will require a major version bump, so I'm inclined to not bother until its necessary.

I expect test failures, something about `django_content_type` not existing. I don't know the solution yet, but it only seems to affect the tests, as I'm running this library in production on Django 3.0 right now.

References #90