### PR TITLE
Fix processing of Postgres ArrayField

### DIFF
--- a/aldjemy/postgres.py
+++ b/aldjemy/postgres.py
@@ -13,8 +13,6 @@ def array_type(data_types, field):
     # currently no support for multi-dimensional arrays
     if internal_type in data_types and internal_type != "ArrayField":
         sub_type = data_types[internal_type](field)
-        if not isinstance(sub_type, (list, tuple)):
-            sub_type = [sub_type]
     else:
         raise RuntimeError("Unsupported array element type")
 

--- a/test_project_postgres/sample/tests.py
+++ b/test_project_postgres/sample/tests.py
@@ -71,9 +71,11 @@ class TestArrayField(TestCase):
             ttt.save()
             created_objects.append(ttt)
 
-        query = select([TicTacToeBoard.sa.id, TicTacToeBoard.sa.board]) \
-            .order_by(TicTacToeBoard.sa.id) \
+        query = (
+            select([TicTacToeBoard.sa.id, TicTacToeBoard.sa.board])
+            .order_by(TicTacToeBoard.sa.id)
             .limit(10)
+        )
 
         with get_engine().begin() as connection:
             test_data = connection.execute(query)

--- a/test_project_postgres/sample/tests.py
+++ b/test_project_postgres/sample/tests.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import array
 from sample.models import TicTacToeBoard, JsonModel
+
+from aldjemy.core import get_engine
 
 
 class TestArrayField(TestCase):
@@ -29,6 +32,56 @@ class TestArrayField(TestCase):
         assert query.filter(contains("x")).count() == 2
         assert query.filter(contains("o")).count() == 2
         assert query.filter(contains(" ")).count() == 3
+
+    def test_sa_objects_fetching(self):
+        """
+        Test full object fetching using SQLAlchemy-aldjemy ORM.
+        """
+        boards = [
+            ["x", "o", "x", "o", "o", "x", "x", "x", "o"],  # both (full board)
+            [" ", " ", " ", " ", "x", " ", " ", " ", " "],  # only x
+            [" ", " ", " ", "o", "o", " ", " ", " ", "o"],  # only o
+            [" ", " ", " ", " ", " ", " ", " ", " ", " "],  # none
+        ]
+
+        created_objects = []
+        for board in boards:
+            ttt = TicTacToeBoard(board=board)
+            ttt.save()
+            created_objects.append(ttt)
+
+        test_object = TicTacToeBoard.sa.query().get(created_objects[0].id)
+        assert test_object.id == created_objects[0].id
+        assert test_object.board == boards[0]
+
+    def test_sa_sql_expression_language_fetching(self):
+        """
+        Test full record fetching using SQLAlchemy-aldjemy SQL Expression Language.
+        """
+        boards = [
+            ["x", "o", "x", "o", "o", "x", "x", "x", "o"],  # both (full board)
+            [" ", " ", " ", " ", "x", " ", " ", " ", " "],  # only x
+            [" ", " ", " ", "o", "o", " ", " ", " ", "o"],  # only o
+            [" ", " ", " ", " ", " ", " ", " ", " ", " "],  # none
+        ]
+
+        created_objects = []
+        for board in boards:
+            ttt = TicTacToeBoard(board=board)
+            ttt.save()
+            created_objects.append(ttt)
+
+        query = select([TicTacToeBoard.sa.id, TicTacToeBoard.sa.board]) \
+            .order_by(TicTacToeBoard.sa.id) \
+            .limit(10)
+
+        with get_engine().begin() as connection:
+            test_data = connection.execute(query)
+
+        for t_data, c_object in zip(test_data, created_objects):
+            t_data_id, t_data_board = t_data
+            assert t_data_id == c_object.id
+            assert t_data_board == c_object.board
 
 
 class TestJsonField(TestCase):


### PR DESCRIPTION
During initialization and creation of SQLAlchemy Tables type of ArrayField's child is always a python list.

Test cases for fetching data including ArrayField content via ORM and SQL Expression Language are added.

References #92