### PR TITLE
Remove some unwise public interfaces

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,8 +6,11 @@ Incompatible changes:
 * Dropped support for Python < 3.6.
 * Dropped support for Django < 2.2.
 * Removed ``aldjemy.to_list``.
+* Removed ``aldjemy.core.get_meta``.
 * Removed ``aldjemy.core.Cache.models``.
-  Use ``aldjemy.core.Cache.sa_models`` instead.
+* Removed ``aldjemy.core.Cache.sa_models``.
+* Removed ``aldjemy.core.Cache.meta``.
+* Removed ``aldjemy.orm.prepare_models``.
 
 Deprecations:
 

--- a/aldjemy/apps.py
+++ b/aldjemy/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
-
-from .orm import prepare_models
+from sqlalchemy import MetaData
+from .orm import construct_models
 
 
 class AldjemyConfig(AppConfig):
@@ -8,5 +8,6 @@ class AldjemyConfig(AppConfig):
     verbose_name = "Aldjemy"
 
     def ready(self):
-        # Django App registry is ready. Patch models.
-        prepare_models()
+        # Patch models with SQLAlchemy models
+        for model, sa_model in construct_models(MetaData()).items():
+            model.sa = sa_model

--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -12,7 +12,7 @@ from .sqlite import SqliteWrapper
 import time
 
 
-__all__ = ["get_engine", "get_meta"]
+__all__ = ["get_engine"]
 
 
 class Cache:
@@ -55,12 +55,6 @@ def get_engine(alias="default", **kwargs):
             get_connection_string(alias), pool=pool, **kwargs
         )
     return Cache.engines[alias]
-
-
-def get_meta():
-    if not getattr(Cache, "meta", None):
-        Cache.meta = MetaData()
-    return Cache.meta
 
 
 class DjangoPool(NullPool):

--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -1,8 +1,7 @@
-import warnings
 from collections import deque
 from django.db import connections
 from django.conf import settings
-from sqlalchemy import MetaData, create_engine
+from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 from sqlalchemy.pool import _ConnectionRecord as _ConnectionRecordBase
 

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -4,7 +4,7 @@ from django.db import connections, router
 from django.db.backends import signals
 from django.conf import settings
 
-from .core import get_meta, get_engine, Cache
+from .core import get_engine
 from .table import get_all_django_models, generate_tables
 
 

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -105,14 +105,6 @@ def _extract_model_attrs(metadata, model, sa_models):
     return attrs
 
 
-def prepare_models():
-    metadata = get_meta()
-    models = [model for model in get_all_django_models() if not model._meta.proxy]
-    Cache.sa_models = construct_models(metadata)
-    for model in models:
-        model.sa = Cache.sa_models[model]
-
-
 def construct_models(metadata):
     if not metadata.tables:
         generate_tables(metadata)


### PR DESCRIPTION
I'm going heavy in removing some public interfaces that I think are unwise. This is a breaking release. The core functionality, the `sa` attribute, will not be broken, but I'm hoping that along the way we can just get rid of the `Cache`. I think it's a misfeature. These are some steps in that potential direction.