### PR TITLE
WIP: Use SQLAlchemy 2.0.

### DIFF
--- a/aldjemy/core.py
+++ b/aldjemy/core.py
@@ -29,6 +29,7 @@ SQLALCHEMY_ENGINES = {
     "oracle": "oracle",
 }
 SQLALCHEMY_ENGINES.update(getattr(settings, "ALDJEMY_ENGINES", {}))
+SQLALCHEMY_USE_FUTURE = getattr(settings, "ALDJEMY_SQLALCHEMY_USE_FUTURE", False)
 
 
 def get_engine_string(alias):
@@ -51,6 +52,9 @@ def get_engine(alias="default", **kwargs):
             kwargs["native_datetime"] = True
 
         pool = DjangoPool(alias=alias, creator=None)
+        if SQLALCHEMY_USE_FUTURE:
+            # The future keyword argument can only be set to True.
+            kwargs['future'] = SQLALCHEMY_USE_FUTURE
         Cache.engines[alias] = create_engine(
             get_connection_string(alias), pool=pool, **kwargs
         )

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -9,12 +9,18 @@ from sqlalchemy.orm import registry
 from .core import get_engine
 from .table import generate_tables
 
+SQLALCHEMY_USE_FUTURE = getattr(settings, "ALDJEMY_SQLALCHEMY_USE_FUTURE", False)
+
 
 def get_session(alias="default", recreate=False, **kwargs):
     connection = connections[alias]
     if not hasattr(connection, "sa_session") or recreate:
         engine = get_engine(alias, **kwargs)
-        session = orm.sessionmaker(bind=engine)
+        kwargs = {"bind": engine}
+        if SQLALCHEMY_USE_FUTURE:
+            # The future keyword argument can only be set to True.
+            kwargs['future'] = SQLALCHEMY_USE_FUTURE
+        session = orm.sessionmaker(**kwargs)
         connection.sa_session = session()
     return connection.sa_session
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/aldjemy/aldjemy"
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-SQLAlchemy = ">=1.4"
+SQLAlchemy = "2.0.0rc2"
 Django = ">=3.2"
 
 [tool.poetry.dev-dependencies]

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -15,6 +15,7 @@ DATABASE_ROUTERS = [
 ALDJEMY_DATA_TYPES = {
     "AFakeType": foreign_key,
 }
+ALDJEMY_SQLALCHEMY_USE_FUTURE = True
 
 INSTALLED_APPS = [
     "django.contrib.auth",


### PR DESCRIPTION
Installs SQLAlchemy 2.0.0rc2

Passes future=True for get_engine and Session().

Tests are currently failing.