### PR TITLE
Switch to hatchling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Install with Django ${{ matrix.django-version }}
-        run: pip install "$(ls dist/*.whl)[test]" 'django~=${{ matrix.django-version }}.0'
+        run: pip install "$(ls dist/*.whl)[dev]" 'django~=${{ matrix.django-version }}.0'
       - name: Run tests
         run: pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Install with Django ${{ matrix.django-version }}
-        run: pip install dist/*.whl 'django~=${{ matrix.django-version }}.0'
+        run: pip install "$(ls dist/*.whl)[test]" 'django~=${{ matrix.django-version }}.0'
       - name: Run tests
         run: pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         ports:
           - 5432:5432
     env:
+      PYTHONPATH: .
       SQLALCHEMY_WARN_20: 1
     steps:
       - uses: actions/checkout@v3
@@ -51,11 +52,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.2.0
-      - name: Install dependencies
-        run: poetry install
-      - name: Install Django ${{ matrix.django-version }}
-        run: poetry run pip install -U 'django~=${{ matrix.django-version }}.0'
+      - name: Install prerequisites
+        run: pip install -U pip build
+      - name: Build package
+        run: python -m build
+      - name: Install with Django ${{ matrix.django-version }}
+        run: pip install dist/*.whl 'django~=${{ matrix.django-version }}.0'
       - name: Run tests
-        run: poetry run pytest
+        run: pytest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.2.0
       - name: Install isort
         run: pip install isort
       - name: Isort

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to pypi
+name: Publish to PyPI
 on:
   release:
     types:
@@ -13,16 +13,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.2.0
-      - name: Configure poetry
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run:
-          poetry config pypi-token.pypi $PYPI_TOKEN
+      - name: Install prerequisites
+        run: pip install -U pip build twine
       - name: Build package
-        run:
-          poetry build
-      - name: Publish package
-        run:
-          poetry publish
+        run: python -m build
+      - name: Publish package with twine
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,9 +13,10 @@ Incompatible changes:
 
 Maintenance:
 
- * Add support for Django 4.0
- * Add support for Django 4.1
- * Add support for Python 3.11
+* Add support for Django 4.0
+* Add support for Django 4.1
+* Add support for Python 3.11
+* Explicit non-support for SQLAlchemy 2.0
 
 2.6 (2021-10-27)
 ++++++++++++++++
@@ -36,11 +37,11 @@ Fixes:
 
 Fixes:
 
- * Address some deprecation warnings coming from sqlalchemy 1.4 (#212)
+* Address some deprecation warnings coming from sqlalchemy 1.4 (#212)
 
 Maintenance:
 
- * adopt isort (#210)
+* adopt isort (#210)
 
 2.3 (2021-09-27)
 ++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Release Process
 
     .. code-block:: bash
 
-       poetry version (major|minor|patch) # choose which version to bump
+       hatch version (major|minor|patch) # choose which version to bump
 
  2. Once the pull request is merged, create a github release with the same version, on the web console or with github cli.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,31 @@
-[tool.poetry]
+[project]
 name = "aldjemy"
 version = "2.7"
 description = "SQLAlchemy for your Django models"
-authors = ["Mikhail Krivushin"]
-license = "BSD 3-Clause \"New\" or \"Revised\" License"
+authors = [{ name = "Mikhail Krivushin" }]
+license = "BSD-3-Clause"
 readme = "README.rst"
-homepage = "https://github.com/aldjemy/aldjemy"
-repository = "https://github.com/aldjemy/aldjemy"
+urls.homepage = "https://github.com/aldjemy/aldjemy"
+urls.repository = "https://github.com/aldjemy/aldjemy"
 
-[tool.poetry.dependencies]
-python = ">=3.7"
-SQLAlchemy = ">=1.4"
-Django = ">=3.2"
+requires-python = ">=3.7"
+dependencies = [
+  "SQLAlchemy>=1.4,<2",
+  "Django>=3.2",
+]
 
-[tool.poetry.dev-dependencies]
-psycopg2-binary = "*"
-black = "*"
-pytest = "*"
-pytest-django = "*"
-isort = "*"
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-django",
+    "psycopg2-binary",
+    "black",
+    "isort",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.isort]
 profile = "black"

--- a/tox.ini
+++ b/tox.ini
@@ -7,14 +7,14 @@ isolated_build = True
 
 [testenv]
 setenv =
+    PYTHONPATH=.
     SQLALCHEMY_WARN_20 = 1
-commands =
-    django31: poetry run pip install -U 'django~=3.1.0'
-    django32: poetry run pip install -U 'django~=3.2.0'
-    django40: poetry run pip install -U 'django~=4.0.0'
-    django41: poetry run pip install -U 'django~=4.1.0'
-    poetry run pytest
-allowlist_externals = poetry
+extras = dev
+deps =
+    django32: Django~=3.2.0
+    django40: Django~=4.0.0
+    django41: Django~=4.1.0
+commands = pytest
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_project.settings


### PR DESCRIPTION
I was running into some trouble using `poetry` to do installs. Technically, I could have just used `pip` to install the same as I have here, since `poetry` provides a build backend. However, it seems that poetry has some conflicts in strategy with the broader python community, and I think that the community has valid criticisms. Poetry has done the community a great service with its opinionated approach that drove the ecosystem forward. Thankfully, the tooling has matured, and we have other options that are great and make different trade-offs. For this project, `hatch`'s backend `hatchling` seems like a really good fit.