### PR TITLE
Clean pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
         ports:
           - 5432:5432
     env:
-      PYTHONPATH: .
       SQLALCHEMY_WARN_20: 1
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands = pytest
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_project.settings
+pythonpath = .
 python_files = tests.py test_*.py *_tests.py
 filterwarnings =
     error

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ isolated_build = True
 
 [testenv]
 setenv =
-    PYTHONPATH=.
     SQLALCHEMY_WARN_20 = 1
 extras = dev
 deps =


### PR DESCRIPTION
So that I can run pytest without additional arguments, use the `pythonpath` configuration to include the working directory by default.