### PR TITLE
Decouple model generation from the session magic

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,19 @@ Incompatible changes:
 
 * Dropped support for Python < 3.7.
 * Dropped support for Django < 3.2.
+* Removed the ``alias`` property from the generated models.
+  It was intended for internal use only.
+* Removed the ``table`` property from the generated models.
+  It is redundant with the ``__table__`` property.
+* Moved the ``get_session`` function from ``aldjemy.orm``
+  to ``aldjemy.session``.
+* Removed the ``query`` method from models generated
+  directly using ``construct_models``.
+* Changed the ``__name__`` and ``repr()`` of models generated
+  directly using ``construct_models``.
+* Moved the ``BaseSQLAModel`` class from ``aldjemy.orm``
+  to ``aldjemy.apps``, because it is an implementation detail
+  of the default app integration.
 
 Maintenance:
 

--- a/aldjemy/apps.py
+++ b/aldjemy/apps.py
@@ -1,6 +1,9 @@
 from django.apps import AppConfig
+from django.conf import settings
+from django.db.backends import signals
 from sqlalchemy import MetaData
 
+from .session import get_session
 from .orm import construct_models
 
 
@@ -12,3 +15,12 @@ class AldjemyConfig(AppConfig):
         # Patch models with SQLAlchemy models
         for model, sa_model in construct_models(MetaData()).items():
             model.sa = sa_model
+
+
+
+def new_session(sender, connection, **kwargs):
+    if connection.alias in settings.DATABASES:
+        get_session(alias=connection.alias, recreate=True)
+
+
+signals.connection_created.connect(new_session)

--- a/aldjemy/apps.py
+++ b/aldjemy/apps.py
@@ -1,11 +1,11 @@
 from django.apps import AppConfig
 from django.conf import settings
-from django.db.backends import signals
 from django.db import router
+from django.db.backends import signals
 from sqlalchemy import MetaData
 
-from .session import get_session
 from .orm import construct_models
+from .session import get_session
 
 
 def new_session(sender, connection, **kwargs):

--- a/aldjemy/apps.py
+++ b/aldjemy/apps.py
@@ -7,6 +7,12 @@ from .session import get_session
 from .orm import construct_models
 
 
+def new_session(sender, connection, **kwargs):
+    """Create a new session for the given connection."""
+    if connection.alias in settings.DATABASES:
+        get_session(alias=connection.alias, recreate=True)
+
+
 class AldjemyConfig(AppConfig):
     name = "aldjemy"
     verbose_name = "Aldjemy"
@@ -16,11 +22,4 @@ class AldjemyConfig(AppConfig):
         for model, sa_model in construct_models(MetaData()).items():
             model.sa = sa_model
 
-
-
-def new_session(sender, connection, **kwargs):
-    if connection.alias in settings.DATABASES:
-        get_session(alias=connection.alias, recreate=True)
-
-
-signals.connection_created.connect(new_session)
+        signals.connection_created.connect(new_session)

--- a/aldjemy/apps.py
+++ b/aldjemy/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
 from django.conf import settings
 from django.db.backends import signals
+from django.db import router
 from sqlalchemy import MetaData
 
 from .session import get_session
@@ -13,13 +14,40 @@ def new_session(sender, connection, **kwargs):
         get_session(alias=connection.alias, recreate=True)
 
 
+class BaseSQLAModel:
+    @classmethod
+    def query(cls, *args, **kwargs):
+        alias = getattr(cls, "__alias__", "default")
+        if args or kwargs:
+            return get_session(alias).query(*args, **kwargs)
+        return get_session(alias).query(cls)
+
+
+def _make_sa_model(model):
+    """Create a custom class for the SQLAlchemy model."""
+    mixin = getattr(model, "aldjemy_mixin", None)
+    bases = (mixin, BaseSQLAModel) if mixin else (BaseSQLAModel,)
+
+    # because querying happens on sqlalchemy side, we can use only one
+    # type of queries for alias, so we use 'read' type
+    return type(
+        model._meta.object_name + ".sa",
+        bases,
+        {
+            "__alias__": router.db_for_read(model),
+            "__module__": model.__module__,
+        },
+    )
+
+
 class AldjemyConfig(AppConfig):
     name = "aldjemy"
     verbose_name = "Aldjemy"
 
     def ready(self):
         # Patch models with SQLAlchemy models
-        for model, sa_model in construct_models(MetaData()).items():
+        models = construct_models(MetaData(), _make_sa_model=_make_sa_model)
+        for model, sa_model in models.items():
             model.sa = sa_model
 
         signals.connection_created.connect(new_session)

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -1,4 +1,5 @@
 from typing import Callable
+
 from django.apps import apps
 from django.db.models.fields.related import ForeignKey, ManyToManyField, OneToOneField
 from sqlalchemy import orm

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -1,27 +1,13 @@
 from django.apps import apps
 from django.conf import settings
-from django.db import connections, router
+from django.db import router
 from django.db.backends import signals
 from django.db.models.fields.related import ForeignKey, ManyToManyField, OneToOneField
 from sqlalchemy import orm
 from sqlalchemy.orm import registry
 
-from .core import get_engine
+from .session import get_session
 from .table import generate_tables
-
-SQLALCHEMY_USE_FUTURE = getattr(settings, "ALDJEMY_SQLALCHEMY_USE_FUTURE", None)
-
-
-def get_session(alias="default", recreate=False, **kwargs):
-    connection = connections[alias]
-    if not hasattr(connection, "sa_session") or recreate:
-        engine = get_engine(alias, **kwargs)
-        kwargs = {"bind": engine}
-        if SQLALCHEMY_USE_FUTURE is not None:
-            kwargs["future"] = SQLALCHEMY_USE_FUTURE
-        session = orm.sessionmaker(**kwargs)
-        connection.sa_session = session()
-    return connection.sa_session
 
 
 def new_session(sender, connection, **kwargs):

--- a/aldjemy/orm.py
+++ b/aldjemy/orm.py
@@ -1,21 +1,11 @@
 from django.apps import apps
-from django.conf import settings
 from django.db import router
-from django.db.backends import signals
 from django.db.models.fields.related import ForeignKey, ManyToManyField, OneToOneField
 from sqlalchemy import orm
 from sqlalchemy.orm import registry
 
 from .session import get_session
 from .table import generate_tables
-
-
-def new_session(sender, connection, **kwargs):
-    if connection.alias in settings.DATABASES:
-        get_session(alias=connection.alias, recreate=True)
-
-
-signals.connection_created.connect(new_session)
 
 
 def _extract_model_attrs(metadata, model, sa_models):

--- a/aldjemy/session.py
+++ b/aldjemy/session.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.db import connections
+from sqlalchemy import orm
+
+from .core import get_engine
+
+
+SQLALCHEMY_USE_FUTURE = getattr(settings, "ALDJEMY_SQLALCHEMY_USE_FUTURE", None)
+
+
+def get_session(alias="default", recreate=False, **kwargs):
+    connection = connections[alias]
+    if not hasattr(connection, "sa_session") or recreate:
+        engine = get_engine(alias, **kwargs)
+        kwargs = {"bind": engine}
+        if SQLALCHEMY_USE_FUTURE is not None:
+            kwargs["future"] = SQLALCHEMY_USE_FUTURE
+        session = orm.sessionmaker(**kwargs)
+        connection.sa_session = session()
+    return connection.sa_session

--- a/aldjemy/session.py
+++ b/aldjemy/session.py
@@ -4,7 +4,6 @@ from sqlalchemy import orm
 
 from .core import get_engine
 
-
 SQLALCHEMY_USE_FUTURE = getattr(settings, "ALDJEMY_SQLALCHEMY_USE_FUTURE", None)
 
 

--- a/test_project/pg/tests.py
+++ b/test_project/pg/tests.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import array
 
 from aldjemy.core import get_engine
-from aldjemy.orm import get_session
+from aldjemy.session import get_session
 from test_project.pg.models import DateRangeModel, JsonModel, TicTacToeBoard
 
 

--- a/test_project/sample/tests.py
+++ b/test_project/sample/tests.py
@@ -102,7 +102,7 @@ class CustomMetaDataTests(TestCase):
         # and the automatically generation of aldjemy.
         metadata = MetaData(schema="arbitrary")
         sa_models = construct_models(metadata)
-        self.assertEqual(sa_models[Log].table.schema, "arbitrary")
+        self.assertEqual(sa_models[Log].__table__.schema, "arbitrary")
 
     def test_custom_metadata_schema_aliased(self):
         """Make sure the aliased command works with the schema."""
@@ -120,7 +120,7 @@ class CustomMetaDataTests(TestCase):
 
         metadata = MetaData(schema="unique")
         sa_models = construct_models(metadata)
-        self.assertEqual(sa_models[through].table.schema, "unique")
+        self.assertEqual(sa_models[through].__table__.schema, "unique")
 
     def test_many_to_many_through_self_aliased(self):
         """Make sure aliased recursive through tables work."""
@@ -138,11 +138,11 @@ class ForeignKeyTests(TestCase):
         metadata = MetaData(schema="unique")
         sa_models = construct_models(metadata)
         sa_model = sa_models[RelatedToItemViaPrimaryKey]
-        table = sa_model.table
+        table = sa_model.__table__
         self.assertEqual(len(table.foreign_keys), 1)
         foreign_key, *_ = table.foreign_keys
         foreign_column = foreign_key.column
-        item_table = sa_models[Item].table
+        item_table = sa_models[Item].__table__
         self.assertIs(foreign_column.table, item_table)
         self.assertEqual(foreign_column.name, "id")
         self.assertEqual(foreign_column.type, item_table.c.id.type)
@@ -152,11 +152,11 @@ class ForeignKeyTests(TestCase):
         metadata = MetaData(schema="unique")
         sa_models = construct_models(metadata)
         sa_model = sa_models[RelatedToItemViaUniqueField]
-        table = sa_model.table
+        table = sa_model.__table__
         self.assertEqual(len(table.foreign_keys), 1)
         foreign_key, *_ = table.foreign_keys
         foreign_column = foreign_key.column
-        item_table = sa_models[Item].table
+        item_table = sa_models[Item].__table__
         self.assertIs(foreign_column.table, item_table)
         self.assertEqual(foreign_column.name, "legacy_id")
         self.assertEqual(foreign_column.type, item_table.c.legacy_id.type)

--- a/test_project/sample/tests.py
+++ b/test_project/sample/tests.py
@@ -5,7 +5,8 @@ from sqlalchemy import MetaData
 from sqlalchemy.orm import aliased
 
 from aldjemy.core import Cache, get_connection_string, get_engine
-from aldjemy.orm import construct_models, get_session
+from aldjemy.session import get_session
+from aldjemy.orm import construct_models
 from test_project.sample.models import (
     Author,
     Book,

--- a/test_project/sample/tests.py
+++ b/test_project/sample/tests.py
@@ -5,8 +5,8 @@ from sqlalchemy import MetaData
 from sqlalchemy.orm import aliased
 
 from aldjemy.core import Cache, get_connection_string, get_engine
-from aldjemy.session import get_session
 from aldjemy.orm import construct_models
+from aldjemy.session import get_session
 from test_project.sample.models import (
     Author,
     Book,


### PR DESCRIPTION
While I've been long thinking it, the issues figuring out compatibility for SQLAlchemy 2.0 have cemented for me that the model generation should be considered separately from the session handling. Aldjemy combines these two subsystems in a really neat way, but the model generation is worthwhile even if the session handling isn't working right.

Since I'm currently having some trouble upgrading the deep internals of the session handling, and because it seems like a proper boundary anyway, I want to lean into that a bit and split things up that way.

To simplify things, this also includes some breaking changes, noted in the HISTORY file. These changes are not important enough to prompt a release yet, but I believe will help us maintain this project.

